### PR TITLE
SW-79 feat(login): Add login & sign up request

### DIFF
--- a/app/common/header/Login.js
+++ b/app/common/header/Login.js
@@ -9,13 +9,13 @@ import { useRouter } from 'next/navigation';
 
 const Login = () => {
     let [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
-    let [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false)
+    let [isSignupModalOpen, setIsSignupModalOpen] = useState(false)
  
-    function openLoginModal() { setIsLoginModalOpen(true); setIsRegisterModalOpen(false); setEmailMessage("") }
-    function closeLoginModal() { setIsLoginModalOpen(false); setIsRegisterModalOpen(false) }
+    function openLoginModal() { setIsLoginModalOpen(true); setIsSignupModalOpen(false); setEmailMessage("") }
+    function closeLoginModal() { setIsLoginModalOpen(false); setIsSignupModalOpen(false) }
    
-    function openRegisterModal() { setIsRegisterModalOpen(true); setIsLoginModalOpen(false), setEmailMessage(""), setPasswordMessage(""), setPasswordConfirmMessage(""), setCheckAuthMessage(""), setAuthMessage("")}
-    function closeRegisterModal() { setIsLoginModalOpen(false); setIsRegisterModalOpen(false), setIsEmail(false) }
+    function openSignupModal() { setIsSignupModalOpen(true); setIsLoginModalOpen(false), setEmailMessage(""), setPasswordMessage(""), setPasswordConfirmMessage(""), setCheckAuthMessage(""), setAuthMessage("")}
+    function closeSignupModal() { setIsLoginModalOpen(false); setIsSignupModalOpen(false), setIsEmail(false) }
     
     const router = useRouter();
 
@@ -345,7 +345,7 @@ const Login = () => {
                               </div>
 
                               <div className="relative w-full mt-4 mb-2">
-                                <p>회원이 아니신가요?  <strong onClick={openRegisterModal} className='text-red-400 hover:text-red-500'>회원 가입하기</strong></p>
+                                <p>회원이 아니신가요?  <strong onClick={openSignupModal} className='text-red-400 hover:text-red-500'>회원 가입하기</strong></p>
                               </div>
                             </form>
                           </div>
@@ -377,8 +377,8 @@ const Login = () => {
             </Transition>
 
             {/* 회원가입 Modal */}
-            <Transition className="z-50 overflow-auto" appear show={isRegisterModalOpen} as={Fragment}>
-              <Dialog as="div" className="relative z-50" onClose={closeRegisterModal}>
+            <Transition className="z-50 overflow-auto" appear show={isSignupModalOpen} as={Fragment}>
+              <Dialog as="div" className="relative z-50" onClose={closeSignupModal}>
                 <Transition.Child
                   as={Fragment}
                   enter="ease-out duration-300"
@@ -407,7 +407,7 @@ const Login = () => {
                         <div className='flex justify-end'>
                           <XMarkIcon
                             className="w-6 h-6 text-sm text-zinc-500 "
-                            onClick={closeRegisterModal}
+                            onClick={closeSignupModal}
                           />
                         </div>
 
@@ -553,7 +553,7 @@ const Login = () => {
                           </div>
 
                           <div className="mb-3 text-center">
-                            <h6 onClick={() => {closeRegisterModal(); openLoginModal();}} className="text-sm font-bold text-zinc-400">
+                            <h6 onClick={() => {closeSignupModal(); openLoginModal();}} className="text-sm font-bold text-zinc-400">
                               로그인 화면으로 돌아가기
                             </h6>
                           </div>

--- a/app/common/header/Login.js
+++ b/app/common/header/Login.js
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { Dialog, Transition } from '@headlessui/react';
 import KakaoLoginBtn from '../../../public/images/KakaoLogin.png'
 import { XMarkIcon } from '@heroicons/react/24/outline';
+import { useRouter } from 'next/navigation';
 
 const Login = () => {
     let [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
@@ -16,6 +17,8 @@ const Login = () => {
     function openRegisterModal() { setIsRegisterModalOpen(true); setIsLoginModalOpen(false), setEmailMessage(""), setPasswordMessage(""), setPasswordConfirmMessage(""), setCheckAuthMessage(""), setAuthMessage("")}
     function closeRegisterModal() { setIsLoginModalOpen(false); setIsRegisterModalOpen(false), setIsEmail(false) }
     
+    const router = useRouter();
+
     // 사용자 입력 변수
     const userName = useRef("");
     const userEmail = useRef("");
@@ -109,6 +112,60 @@ const Login = () => {
         }
     };
 
+    async function requestLogin(){
+      
+      console.log("로그인 버튼 눌림");
+
+      if(!userPassword.current) {
+        alert("비밀번호를 입력해 주세요 😮");
+        return;
+      }
+
+      //로그인 api 호출
+      console.log("======= Login Request");
+      const data = new Object();
+      console.log("userEmail : " + userEmail.current);
+      console.log("userPassword : " + userPassword.current);
+      data.loginId = userEmail.current;
+      data.password = userPassword.current;
+      
+      const requestLoginBody = {
+          loginId: userEmail.current,
+          password: userPassword.current
+      }
+      
+      try{
+          const responseLogin = await fetch('/api//v0/members/login', {
+              method: 'POST',
+              body: JSON.stringify(requestLoginBody),
+              headers: {
+                  'Content-type': 'application/json',
+              }
+          });
+
+          /*
+          * TODO: accessToken / 로그인 상태 / 만료 시간 저장 기능
+          
+          const responseData = await responseLogin.json();
+          let responseDataJson = JSON.parse(responseData);
+
+          //recoil에 accessToken 저장
+          setAcctoken(responseDataJson.accessToken);
+          
+          //로그인 상태와 만료 시간 sessionStorage에 저장
+          sessionStorage.setItem("isLogin","true")
+          sessionStorage.setItem("expTime",responseDataJson.expTime)
+
+          */
+
+          router.push('/diary/dashboard');
+          return;
+      }catch(e){
+          console.log(e);
+          alert("로그인에 실패했습니다. 다시 시도해 주세요.");
+      }
+  }
+
     async function requestSignup(){
 
       console.log("회원가입 버튼 눌림");
@@ -128,22 +185,22 @@ const Login = () => {
       data.password = userPassword.current;
       data.username = userName.current;
 
-      const requestBody = {
+      const requestSignupBody = {
           loginId: userEmail.current,
           password: userPassword.current,
           username: userName.current
       }
       
       try{
-          const response = await fetch('/api/v0/members/register', {
+          const responseSignup = await fetch('/api/v0/members/register', {
               method: 'POST',
-              body: JSON.stringify(requestBody),
+              body: JSON.stringify(requestSignupBody),
               headers: {
                   'Content-type': 'application/json',
               }
           });
           //check
-          // console.log("Result : " + JSON.stringify(response));
+          // console.log("Result : " + JSON.stringify(responseSignup));
           // console.log("User email : "+ response["email"]);
           
           alert("회원가입이 완료되었습니다 😊");
@@ -262,6 +319,7 @@ const Login = () => {
                                       type="password"
                                       className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
                                       placeholder="Password"
+                                      onChange={onPasswordChange}
                                     />
                                   </div>
                                 </div>
@@ -279,6 +337,8 @@ const Login = () => {
                                 <button
                                   className="w-full px-6 py-3 mb-1 mr-1 text-sm font-bold text-white uppercase transition-all duration-150 ease-linear rounded shadow outline-none bg-zinc-800 active:bg-zinc-600 hover:shadow-lg focus:outline-none"
                                   type="button"
+                                  onClick={requestLogin}
+                                  disabled={!isEmail}
                                 >
                                   로그인
                                 </button>

--- a/app/common/header/Login.js
+++ b/app/common/header/Login.js
@@ -39,6 +39,10 @@ const Login = () => {
     const [isEmail, setIsEmail] = useState(false)
     const [isPassword, setIsPassword] = useState(false)
     const [isPasswordConfirm, setIsPasswordConfirm] = useState(false)
+    
+    const onNameChange = (e) => {
+      userName.current = e.target.value;
+    };
 
     // 이메일 검증
     const onEmailChange = (e) => {
@@ -92,6 +96,7 @@ const Login = () => {
           setIsPassword(true)
       }
     };
+
     const onPasswordCheckChange = (e) => {
         userPasswordCheck.current = e.target.value;
         // console.log("userPasswordCheck : "+userPasswordCheck.current);
@@ -102,6 +107,51 @@ const Login = () => {
             setPasswordConfirmMessage('비밀번호가 달라요. 다시 확인해주세요 😢')
             setIsPasswordConfirm(false)
         }
+    };
+
+    async function requestSignup(){
+
+      console.log("회원가입 버튼 눌림");
+
+      if(!userName.current){
+          alert("이름을 입력해 주세요 😮");
+          return;
+      }
+
+      //회원가입 api 호출
+      console.log("======= SignUp Request");
+      const data = new Object();
+      console.log("userEmail : " + userEmail.current);
+      console.log("userPassword : " + userPassword.current);
+      console.log("userName : " + userName.current);
+      data.loginId = userEmail.current;
+      data.password = userPassword.current;
+      data.username = userName.current;
+
+      const requestBody = {
+          loginId: userEmail.current,
+          password: userPassword.current,
+          username: userName.current
+      }
+      
+      try{
+          const response = await fetch('/api/v0/members/register', {
+              method: 'POST',
+              body: JSON.stringify(requestBody),
+              headers: {
+                  'Content-type': 'application/json',
+              }
+          });
+          //check
+          // console.log("Result : " + JSON.stringify(response));
+          // console.log("User email : "+ response["email"]);
+          
+          alert("회원가입이 완료되었습니다 😊");
+          openLoginModal();
+      } catch (e) {
+          console.log(e);
+          alert("회원가입에 실패했습니다. 다시 시도해 주세요.");
+      }
     };
 
     const sendAuthMail =()=>{
@@ -322,6 +372,7 @@ const Login = () => {
                                       type="text"
                                       className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
                                       placeholder="Name"
+                                      onChange={onNameChange}
                                     />
                                   </div>
                                 </div>
@@ -432,6 +483,8 @@ const Login = () => {
                                 <button
                                   className="w-full px-6 py-3 mb-1 mr-1 text-sm font-bold text-white uppercase transition-all duration-150 ease-linear rounded shadow outline-none bg-zinc-800 active:bg-zinc-600 hover:shadow-lg focus:outline-none"
                                   type="button"
+                                  disabled={!(isEmail && isPassword && isPasswordConfirm && isAuthConfirm)}
+                                  onClick={requestSignup}
                                 >
                                   회원가입
                                 </button>

--- a/app/common/header/Login.js
+++ b/app/common/header/Login.js
@@ -13,19 +13,19 @@ const Login = () => {
     function openLoginModal() { setIsLoginModalOpen(true); setIsRegisterModalOpen(false); setEmailMessage("") }
     function closeLoginModal() { setIsLoginModalOpen(false); setIsRegisterModalOpen(false) }
    
-    function openRegisterModal() { setIsRegisterModalOpen(true); setIsLoginModalOpen(false), setEmailMessage(""), setPasswordMessage(""), setPasswordConfirmMessage(""), setChkAuthMessage(""), setAuthMessage("")}
+    function openRegisterModal() { setIsRegisterModalOpen(true); setIsLoginModalOpen(false), setEmailMessage(""), setPasswordMessage(""), setPasswordConfirmMessage(""), setCheckAuthMessage(""), setAuthMessage("")}
     function closeRegisterModal() { setIsLoginModalOpen(false); setIsRegisterModalOpen(false), setIsEmail(false) }
     
     // 사용자 입력 변수
     const userName = useRef("");
     const userEmail = useRef("");
-    const userPw = useRef("");
-    const userPwChk = useRef("");
+    const userPassword = useRef("");
+    const userPasswordCheck = useRef("");
 
     // 메일 인증 변수
     const userAuth = useRef(""); // 인증번호 입력값
     const [authMessage, setAuthMessage] = useState('') // 인증번호 오류 메세지
-    const [chkAuthMessage, setChkAuthMessage] = useState('') // 인증번호 확인 요청 메시지
+    const [checkAuthMessage, setCheckAuthMessage] = useState('') // 인증번호 확인 요청 메시지
     const [isAuthConfirm, setIsAuthConfirm] = useState(false) // 인증 번호가 일치하는지 확인
     let randNum = useRef("00000"); // 인증번호
     let [isAuthIng, setIsAuthIng] = useState(false) // 메일 인증 중인지 확인
@@ -48,15 +48,15 @@ const Login = () => {
       // console.log("Email : "+userEmail.current);
 
       if (!emailRegex.test(userEmail.current)) {
-          setEmailMessage('이메일 형식이 틀렸습니다. 다시 확인해 주세요😢')
+          setEmailMessage('이메일 형식이 틀렸습니다. 다시 확인해 주세요 😢')
           setIsEmail(false)
           // 메일 변경 시 인증번호 창 다시 막고, 인증 다시하도록 인증 관련 변수 초기화
           setIsAuthConfirm(false)
           setAuthMessage('')
           setIsAuthIng(false)
-          setChkAuthMessage('');
+          setCheckAuthMessage('');
       } else {
-          setEmailMessage('올바른 이메일 형식입니다✅')
+          setEmailMessage('올바른 이메일 형식입니다 ✅')
           //인증번호 발급
           randNum.current = parseInt(Math.random() * 100000 + "");
           setIsEmail(true)
@@ -68,38 +68,38 @@ const Login = () => {
       // console.log("인증번호##" + randNum.current)
 
       if (randNum.current != userAuth.current) {
-          setAuthMessage('인증 번호가 틀렸습니다. 다시 확인해 주세요😢')
+          setAuthMessage('인증 번호가 틀렸습니다. 다시 확인해 주세요 😢')
           setIsAuthConfirm(false)
       } else {
-          setAuthMessage('인증 번호가 확인되었습니다. ✅')
+          setAuthMessage('인증 번호가 확인되었습니다 ✅')
           setIsAuthConfirm(true)
       }
     };
   
     // 비밀번호 검증
-    const onPwChange = (e) => {
+    const onPasswordChange = (e) => {
       setIsPasswordConfirm(false);
-      setPasswordConfirmMessage('비밀번호가 달라요. 다시 확인해주세요😢')
+      setPasswordConfirmMessage('비밀번호가 달라요. 다시 확인해주세요 😢')
 
       const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,25}$/
-      userPw.current = e.target.value;
-      // console.log("userPw : "+userPw.current);
-      if (!passwordRegex.test(userPw.current)) {
-          setPasswordMessage('숫자+영문자+특수문자 조합으로 8자리 이상 입력해 주세요🚨')
+      userPassword.current = e.target.value;
+      // console.log("userPassword : "+userPassword.current);
+      if (!passwordRegex.test(userPassword.current)) {
+          setPasswordMessage('숫자+영문자+특수문자 조합으로 8자리 이상 입력해 주세요 🚨')
           setIsPassword(false)
       } else {
-          setPasswordMessage('안전한 비밀번호입니다✅')
+          setPasswordMessage('안전한 비밀번호입니다 ✅')
           setIsPassword(true)
       }
     };
-    const onPwChkChange = (e) => {
-        userPwChk.current = e.target.value;
-        // console.log("userPwChk : "+userPwChk.current);
-        if (userPw.current === userPwChk.current) {
-            setPasswordConfirmMessage('비밀번호를 똑같이 입력했어요✅')
+    const onPasswordCheckChange = (e) => {
+        userPasswordCheck.current = e.target.value;
+        // console.log("userPasswordCheck : "+userPasswordCheck.current);
+        if (userPassword.current === userPasswordCheck.current) {
+            setPasswordConfirmMessage('비밀번호를 똑같이 입력했어요 ✅')
             setIsPasswordConfirm(true)
         } else {
-            setPasswordConfirmMessage('비밀번호가 달라요. 다시 확인해주세요😢')
+            setPasswordConfirmMessage('비밀번호가 달라요. 다시 확인해주세요 😢')
             setIsPasswordConfirm(false)
         }
     };
@@ -119,7 +119,7 @@ const Login = () => {
       // 인증번호 test 코드
       console.log("============== "+randNum.current)
       setIsAuthIng(true)
-      setChkAuthMessage("메일을 전송하였습니다. 확인 후 인증번호를 입력해 주세요.");
+      setCheckAuthMessage("메일을 전송하였습니다. 확인 후 인증번호를 입력해 주세요.");
      
     };
 
@@ -358,7 +358,7 @@ const Login = () => {
                                 >
                                   인증메일 전송
                                 </button>
-                                {(<span className="text-xs text-blue-500">{chkAuthMessage}</span>)}
+                                {(<span className="text-xs text-blue-500">{checkAuthMessage}</span>)}
                               </div>
 
                               <div className="relative w-full mb-3">
@@ -399,11 +399,11 @@ const Login = () => {
                                       type="password"
                                       className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
                                       placeholder="Password"
-                                      onChange={onPwChange}
+                                      onChange={onPasswordChange}
                                     />
                                   </div>
                                 </div>
-                                {userPw.current.length > 0 && <span className={`message ${isPassword ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{passwordMessage}</span>}
+                                {userPassword.current.length > 0 && <span className={`message ${isPassword ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{passwordMessage}</span>}
                               </div>
                               
                               <div className="relative w-full mb-5">
@@ -421,11 +421,11 @@ const Login = () => {
                                       type="password"
                                       className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
                                       placeholder="Password"
-                                      onChange={onPwChkChange}
+                                      onChange={onPasswordCheckChange}
                                     />
                                   </div>
                                 </div>
-                                {userPwChk.current.length > 0 && <span className={`message ${isPasswordConfirm ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{passwordConfirmMessage}</span>}
+                                {userPasswordCheck.current.length > 0 && <span className={`message ${isPasswordConfirm ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{passwordConfirmMessage}</span>}
                               </div>
                               
                               <div className="mt-6 text-center">

--- a/app/common/header/Login.js
+++ b/app/common/header/Login.js
@@ -170,39 +170,51 @@ const Login = () => {
                         </div>
 
                         <div className='flex flex-col text-center justify-items-center'>
-                          <div className="flex-auto px-4 py-10 pt-2 lg:px-10">
+                          <div className="flex-auto px-4 py-4 pt-2 lg:px-10">
                             <div className="mb-5 text-2xl font-bold text-center text-zinc-700">
                               로그인
                             </div>
                             <form>
                               <div className="relative w-full mb-3">
-                                <label
-                                  className="block mb-2 text-xs font-bold uppercase text-zinc-600"
-                                  htmlFor="grid-password"
-                                >
-                                  이메일
-                                </label>
-                                <input
-                                  type="email"
-                                  className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
-                                  placeholder="Email"
-                                  onChange={onEmailChange}
-                                />
-                                {userEmail.current.length > 0 && <span className={`message ${isEmail ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{emailMessage}</span>}
+                                <div class="grid grid-cols-7 gap-1">
+                                  <div class="col-span-2">
+                                    <label
+                                      className="block mb-2 pt-2 text-m font-bold uppercase text-zinc-600"
+                                      htmlFor="grid-password"
+                                    >
+                                      이메일
+                                    </label>
+                                  </div>
+                                  <div class="col-span-5">
+                                    <input
+                                      type="email"
+                                      className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
+                                      placeholder="Email"
+                                      onChange={onEmailChange}
+                                    />
+                                    {userEmail.current.length > 0 && <span className={`message ${isEmail ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{emailMessage}</span>}
+                                  </div>
+                                </div>
                               </div>
 
                               <div className="relative w-full mb-5">
-                                <label
-                                  className="block mb-2 text-xs font-bold uppercase text-zinc-600"
-                                  htmlFor="grid-password"
-                                >
-                                  비밀번호
-                                </label>
-                                <input
-                                  type="password"
-                                  className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
-                                  placeholder="Password"
-                                />
+                                <div class="grid grid-cols-7 gap-1">  
+                                  <div class="col-span-2">
+                                    <label
+                                      className="block mb-2 pt-2 text-m font-bold uppercase text-zinc-600"
+                                      htmlFor="grid-password"
+                                    >
+                                      비밀번호
+                                    </label>
+                                  </div>
+                                  <div class="col-span-5">
+                                    <input
+                                      type="password"
+                                      className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
+                                      placeholder="Password"
+                                    />
+                                  </div>
+                                </div>
                               </div>
                               <div>
                                 <label className="inline-flex items-center cursor-pointer">
@@ -296,36 +308,48 @@ const Login = () => {
                             </div>
                             <form>
                               <div className="relative w-full mb-3">
-                                <label
-                                  className="block mb-2 text-xs font-bold uppercase text-zinc-600"
-                                  htmlFor="grid-password"
-                                >
-                                  이름
-                                </label>
-                                <input
-                                  type="text"
-                                  className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
-                                  placeholder="Name"
-                                />
+                                <div class="grid grid-cols-7 gap-1">
+                                  <div class="col-span-2">
+                                    <label
+                                      className="block mb-2 pt-2 text-m font-bold uppercase text-zinc-600"
+                                      htmlFor="grid-password"
+                                    >
+                                      이름
+                                    </label>
+                                  </div>
+                                  <div class="col-span-5">
+                                    <input
+                                      type="text"
+                                      className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
+                                      placeholder="Name"
+                                    />
+                                  </div>
+                                </div>
                               </div>
 
                               <div className="relative w-full mb-3">
-                                <label
-                                  className="block mb-2 text-xs font-bold uppercase text-zinc-600"
-                                  htmlFor="grid-password"
-                                >
-                                  이메일
-                                </label>
-                                <input
-                                  type="email"
-                                  className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
-                                  placeholder="Email"
-                                  onChange={onEmailChange}
-                                />
+                                <div class="grid grid-cols-7 gap-1">
+                                  <div class="col-span-2">
+                                    <label
+                                      className="block mb-2 pt-2 text-m font-bold uppercase text-zinc-600"
+                                      htmlFor="grid-password"
+                                    >
+                                      이메일
+                                    </label>
+                                  </div>
+                                  <div class="col-span-5">
+                                    <input
+                                      type="email"
+                                      className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
+                                      placeholder="Email"
+                                      onChange={onEmailChange}
+                                    />
+                                  </div>
+                                </div>
                                 {userEmail.current.length > 0 && <span className={`message ${isEmail ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{emailMessage}</span>}
                               </div>
 
-                              <div className="mt-6 text-center">
+                              <div className="mt-3 mb-3 text-center">
                                 <button
                                   className="w-full px-6 py-3 mb-1 mr-1 text-sm font-bold text-white uppercase transition-all duration-150 ease-linear rounded shadow outline-none bg-rose-400 active:bg-zinc-600 hover:shadow-lg focus:outline-none"
                                   type="button"
@@ -338,52 +362,72 @@ const Login = () => {
                               </div>
 
                               <div className="relative w-full mb-3">
-                                <label
-                                  className="block mb-2 text-xs font-bold uppercase text-zinc-600"
-                                  htmlFor="grid-verify"
-                                >
-                                  인증번호
-                                </label>
-                                <input
-                                  type="text"
-                                  className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
-                                  placeholder="인증번호를 입력하세요"
-                                  disabled={!(isAuthIng)}
-                                  onChange={onAuthChange}
-                                />
-                                {userAuth.current.length > 0 && <span className={`message ${isAuthConfirm ? 'success text-xs' : 'error text-xs text-red-500'}`}>{authMessage}</span>}
+                                <div class="grid grid-cols-7 gap-1">
+                                  <div class="col-span-2">
+                                    <label
+                                      className="block mb-2 pt-2 text-m font-bold uppercase text-zinc-600"
+                                      htmlFor="grid-verify"
+                                    >
+                                      인증번호
+                                    </label>
+                                  </div>
+                                  <div class="col-span-5">
+                                    <input
+                                      type="text"
+                                      className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
+                                      placeholder="인증번호를 입력하세요"
+                                      disabled={!(isAuthIng)}
+                                      onChange={onAuthChange}
+                                    />
+                                  </div>
+                                </div>
+                                {userAuth.current.length > 0 && <span className={`message ${isAuthConfirm ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{authMessage}</span>}
                               </div>
 
                               <div className="relative w-full mb-5">
-                                <label
-                                  className="block mb-2 text-xs font-bold uppercase text-zinc-600"
-                                  htmlFor="grid-password"
-                                >
-                                  비밀번호
-                                </label>
-                                <input
-                                  type="password"
-                                  className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
-                                  placeholder="Password"
-                                  onChange={onPwChange}
-                                />
+                                <div class="grid grid-cols-7 gap-1">
+                                  <div class="col-span-2">
+                                    <label
+                                      className="block mb-2 pt-2 text-m font-bold uppercase text-zinc-600"
+                                      htmlFor="grid-password"
+                                    >
+                                      비밀번호
+                                    </label>
+                                  </div>
+                                  <div class="col-span-5">
+                                    <input
+                                      type="password"
+                                      className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
+                                      placeholder="Password"
+                                      onChange={onPwChange}
+                                    />
+                                  </div>
+                                </div>
+                                {userPw.current.length > 0 && <span className={`message ${isPassword ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{passwordMessage}</span>}
                               </div>
-                              {userPw.current.length > 0 && <span className={`message ${isPassword ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{passwordMessage}</span>}
+                              
                               <div className="relative w-full mb-5">
-                                <label
-                                  className="block mb-2 text-xs font-bold uppercase text-zinc-600"
-                                  htmlFor="grid-password"
-                                >
-                                  비밀번호 확인
-                                </label>
-                                <input
-                                  type="password"
-                                  className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
-                                  placeholder="Password"
-                                  onChange={onPwChkChange}
-                                />
-                              </div>
+                                <div class="grid grid-cols-7 gap-1">
+                                  <div class="col-span-2">
+                                    <label
+                                      className="block mb-2 pt-2 text-m font-bold uppercase text-zinc-600"
+                                      htmlFor="grid-password"
+                                    >
+                                      비밀번호 확인
+                                    </label>
+                                  </div>
+                                  <div class="col-span-5">
+                                    <input
+                                      type="password"
+                                      className="w-full px-3 py-3 text-sm transition-all duration-150 ease-linear bg-white border-0 rounded shadow placeholder-zinc-300 text-zinc-600 focus:outline-none focus:ring"
+                                      placeholder="Password"
+                                      onChange={onPwChkChange}
+                                    />
+                                  </div>
+                                </div>
                                 {userPwChk.current.length > 0 && <span className={`message ${isPasswordConfirm ? 'success text-xs text-blue-500' : 'error text-xs text-red-500'}`}>{passwordConfirmMessage}</span>}
+                              </div>
+                              
                               <div className="mt-6 text-center">
                                 <button
                                   className="w-full px-6 py-3 mb-1 mr-1 text-sm font-bold text-white uppercase transition-all duration-150 ease-linear rounded shadow outline-none bg-zinc-800 active:bg-zinc-600 hover:shadow-lg focus:outline-none"


### PR DESCRIPTION
# 추가
**1. 로그인 버튼 클릭 시 검증 후 로그인 요청
2. 회원가입 버튼 클릭 시 검증 후 회원가입 요청**
`TODO: accessToken / 로그인 상태 / 만료 시간 저장 기능`

# 변경
**1. 로그인, 회원가입 사용자 입력란에 grid 속성 적용**
<img width="381" alt="image" src="https://user-images.githubusercontent.com/62373980/212261874-f2a4db05-791a-4331-8201-f4f12d4b6bb0.png">

> 위와 같이 입력란 이름과 입력란을 세로 배치에서 가로 배치로 변경<br/>
> 각 입력란에 대한 사용자 안내 메시지가 많아지면 모달이 길어지는 문제로 구조 변경<br/>

**2. 변수명 및 사용자 안내 메시지 형식 통일**
- pw -> password
- chk -> check 


