### PR TITLE
SW-130 feat(data-fetching): Add recent diary date-fetching

### DIFF
--- a/app/ReactQueryWrapper.jsx
+++ b/app/ReactQueryWrapper.jsx
@@ -6,7 +6,7 @@ import { ReactQueryDevtools } from "react-query/devtools"
 const queryClient = new QueryClient({
     queryCache: new QueryCache({
         onError: (error) => {
-            if(error == 'NOT_FOUND_USER' || error == 'NOT_FOUND_AUTHENTICATION' || error == 'SESSION_EXPIRED' || error == 'NO_PERMISSION' || error == 'EMPTY_TOKEN') {
+            if(error == 'NOT_FOUND_USER' || error == 'NOT_FOUND_AUTHENTICATION' || error == 'SESSION_EXPIRED' || error == 'NO_PERMISSION' || error == 'EMPTY_TOKEN' || error == 'NO_AUTHORIZATION') {
                 try {
                     alert("세션이 만료되었거나 유효하지 않은 요청입니다.\n계속하려면 다시 로그인 해주세요.")
                     window.location.href = "/home/landing";

--- a/app/common/header/Profile.js
+++ b/app/common/header/Profile.js
@@ -390,23 +390,33 @@ const Profile = () => {
                                   <div className="mb-1 text-lg text-zinc-600">
                                     최근 일기
                                   </div>
-                                  <div className='flex place-content-center'>
-                                    <div className='mb-2 text-xl font-semibold'>
-                                      {userInfoData.recentDiaries.diaryDate}
+
+                                  {userInfoData.recentDiaries == null ?
+                                    <h4>
+                                      작성한 일기가 없습니다.
+                                    </h4>
+                                    :
+                                    <div>
+                                      <div className='flex place-content-center'>
+                                        <div className='mb-2 text-xl font-semibold'>
+                                          {userInfoData.recentDiaries.diaryDate}
+                                        </div>
+                                      </div>
+                                      <div className='flex place-content-center'>
+                                        <div className='w-1/3 text-zinc-500 text-m'>
+                                            {userInfoData.recentDiaries.emotion}
+                                        </div>
+                                        <div className='relative flex'>
+                                            {userInfoData.recentDiaries.keywords.map((keyword) => (
+                                                <div key={keyword} className="px-2 py-1 mb-1 mr-2 text-xs font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
+                                                    #{keyword}
+                                                </div>
+                                            ))}
+                                        </div>
+                                      </div>
                                     </div>
-                                  </div>
-                                  <div className='flex place-content-center'>
-                                    <div className='w-1/3 text-zinc-500 text-m'>
-                                        {userInfoData.recentDiaries.emotion}
-                                    </div>
-                                    <div className='relative flex'>
-                                        {userInfoData.recentDiaries.keywords.map((keyword) => (
-                                            <div key={keyword} className="px-2 py-1 mb-1 mr-2 text-xs font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
-                                                #{keyword}
-                                            </div>
-                                        ))}
-                                    </div>
-                                  </div>
+                                  }
+                                  
                                 </div>
                               </div>
                             </div>

--- a/app/common/header/Profile.js
+++ b/app/common/header/Profile.js
@@ -203,7 +203,7 @@ const Profile = () => {
       
       try {
         // 비밀번호 검증 API 호출
-        const checkResponse = await checkPassword(checkData, data.loginId)
+        const checkResponse = await checkPassword(checkData, userInfoData.loginId)
         .then(resp => resp.status != 200 ? resp.json() : resp)
         .then(respData => {
           if(respData.errorCode) {
@@ -212,7 +212,7 @@ const Profile = () => {
         })
 
         // 비밀번호 변경 API 호출
-        const updateResponse = await updatePassword(updateData, data.loginId)
+        const updateResponse = await updatePassword(updateData, userInfoData.loginId)
         .then(resp => resp.status != 200 ? resp.json() : resp)
         .then(respData => {
           if(respData.errorCode) {

--- a/app/common/header/Profile.js
+++ b/app/common/header/Profile.js
@@ -5,7 +5,6 @@ import { Dialog, Transition } from '@headlessui/react';
 import userData from '../../../public/data/user.json'
 import { Fragment, useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import moment from 'moment';
 import { useUserInfoQuery } from '../../hooks/queries/useUserInfoQuery';
 import Loading from './loading';
 import Error from '../../diary/list/grid/error';
@@ -13,7 +12,6 @@ import { useQueryClient } from 'react-query';
 import { useUserInfoUpdate } from '../../hooks/mutations/useUserInfoUpdate';
 import { updatePassword } from '../../api/updatePassword';
 import { checkPassword } from '../../api/checkPassword';
-import { getCookie } from 'cookies-next';
 import { useLogout } from '../../hooks/mutations/useLogout';
 import { uploadImg } from '../../api/uploadImg';
 
@@ -378,7 +376,7 @@ const Profile = () => {
                               <div className="grid grid-cols-3">
                                 
                                 {/* 총 작성한 일기 */}
-                                <div className='col-span-3 mb-1 sm:col-span-1'>
+                                <div className='col-span-3 mb-1 sm:col-span-1 ml-10'>
                                   <div className="mb-1 text-lg text-zinc-600">
                                     총 작성한 일기
                                   </div>
@@ -392,25 +390,26 @@ const Profile = () => {
                                   <div className="mb-1 text-lg text-zinc-600">
                                     최근 일기
                                   </div>
-                                  <div className='mb-2 text-xl font-semibold'>
-                                    {moment(user.recent_diaries[0].date).format("YYYY. MM. DD.")}
+                                  <div className='flex place-content-center'>
+                                    <div className='mb-2 text-xl font-semibold'>
+                                      {userInfoData.recentDiaries.diaryDate}
+                                    </div>
                                   </div>
                                   <div className='flex place-content-center'>
-                                    <div className='w-1/3 pl-5 text-zinc-500'>
-                                      {user.recent_diaries[0].emotion}
+                                    <div className='w-1/3 text-zinc-500 text-m'>
+                                        {userInfoData.recentDiaries.emotion}
                                     </div>
                                     <div className='relative flex'>
-                                      {user.recent_diaries[0].keywords.map((keyword) => (
-                                          <div key={keyword} className="px-2 py-1 mb-1 mr-2 text-xs font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
-                                              #{keyword}
-                                          </div>
-                                      ))}
+                                        {userInfoData.recentDiaries.keywords.map((keyword) => (
+                                            <div key={keyword} className="px-2 py-1 mb-1 mr-2 text-xs font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
+                                                #{keyword}
+                                            </div>
+                                        ))}
                                     </div>
                                   </div>
                                 </div>
                               </div>
                             </div>
-                            
                           </div>
                         </Dialog.Panel>
                       </Transition.Child>

--- a/app/common/header/Profile.js
+++ b/app/common/header/Profile.js
@@ -391,7 +391,7 @@ const Profile = () => {
                                     최근 일기
                                   </div>
 
-                                  {userInfoData.recentDiaries == null ?
+                                  {userInfoData.recentDiary.diaryId == null ?
                                     <h4>
                                       작성한 일기가 없습니다.
                                     </h4>
@@ -399,15 +399,15 @@ const Profile = () => {
                                     <div>
                                       <div className='flex place-content-center'>
                                         <div className='mb-2 text-xl font-semibold'>
-                                          {userInfoData.recentDiaries.diaryDate}
+                                          {userInfoData.recentDiary.diaryDate}
                                         </div>
                                       </div>
                                       <div className='flex place-content-center'>
                                         <div className='w-1/3 text-zinc-500 text-m'>
-                                            {userInfoData.recentDiaries.emotion}
+                                            {userInfoData.recentDiary.emotion}
                                         </div>
                                         <div className='relative flex'>
-                                            {userInfoData.recentDiaries.keywords.map((keyword) => (
+                                            {userInfoData.recentDiary.keywords.map((keyword) => (
                                                 <div key={keyword} className="px-2 py-1 mb-1 mr-2 text-xs font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
                                                     #{keyword}
                                                 </div>

--- a/app/common/header/Profile.js
+++ b/app/common/header/Profile.js
@@ -14,6 +14,7 @@ import { updatePassword } from '../../api/updatePassword';
 import { checkPassword } from '../../api/checkPassword';
 import { useLogout } from '../../hooks/mutations/useLogout';
 import { uploadImg } from '../../api/uploadImg';
+import { getCookie } from 'cookies-next';
 
 const Profile = () => {
 
@@ -313,12 +314,12 @@ const Profile = () => {
                                   />
 
                                   {/* 파일 선택 창 대신 아이콘 사용 */}
-                                  {user.is_social ? 
-                                    <PencilSquareIcon className='hidden text-white w-7 h-7 group-hover:block'/>
+                                  {getCookie("isSocial") ? 
+                                    <></>
                                     :
                                     <label className="signup-profileImg-label" htmlFor="profileImage">
                                       <PencilSquareIcon className='hidden text-white w-7 h-7 group-hover:block'/>
-                                     </label>
+                                    </label>
                                   }
                                 </div>
                               </div>
@@ -340,10 +341,13 @@ const Profile = () => {
                               />
                             </div>
                             {/* 사용자 ID (이메일) */}
-                            <p className="text-sm text-zinc-500">
-                              {userInfoData.loginId}
-                            </p>
-
+                            {getCookie("isSocial") ? 
+                              <></>
+                            :
+                              <p className="text-sm text-zinc-500">
+                                {userInfoData.loginId}
+                              </p>
+                            }
                             <div className='flex items-center justify-center'> 
                               <button
                                   type="button"
@@ -354,7 +358,7 @@ const Profile = () => {
                                 저장하기
                               </button>
                               {/*소셜 로그인 사용자일 경우 비밀번호 변경 불가능*/}
-                              {user.is_social ? 
+                              {getCookie("isSocial") ? 
                                 <></>
                                 :
                                 <div className='justify-center '>
@@ -409,7 +413,7 @@ const Profile = () => {
                                         <div className='relative flex'>
                                             {userInfoData.recentDiary.keywords.map((keyword) => (
                                                 <div key={keyword} className="px-2 py-1 mb-1 mr-2 text-xs font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
-                                                    #{keyword}
+                                                    {keyword == "EXECPTION_NO_KEYWORD" ? <>#키워드 없음</> : <>#{keyword}</>}
                                                 </div>
                                             ))}
                                         </div>

--- a/app/common/header/Profile.js
+++ b/app/common/header/Profile.js
@@ -402,15 +402,15 @@ const Profile = () => {
                                     :
                                     <div>
                                       <div className='flex place-content-center'>
-                                        <div className='mb-2 text-xl font-semibold'>
+                                        <div className='pb-1 text-xl font-semibold'>
                                           {userInfoData.recentDiary.diaryDate}
                                         </div>
                                       </div>
-                                      <div className='flex place-content-center'>
-                                        <div className='w-1/3 text-zinc-500 text-m'>
+                                      <div className='flex place-content-center flex-wrap'>
+                                        <div className='w-1/3 pb-2 text-zinc-500 text-m'>
                                             {userInfoData.recentDiary.emotion}
                                         </div>
-                                        <div className='relative flex'>
+                                        <div className='relative flex flex-wrap justify-center'>
                                             {userInfoData.recentDiary.keywords.map((keyword) => (
                                                 <div key={keyword} className="px-2 py-1 mb-1 mr-2 text-xs font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
                                                     {keyword == "EXECPTION_NO_KEYWORD" ? <>#키워드 없음</> : <>#{keyword}</>}

--- a/app/diary/dashboard/ProfileCard.js
+++ b/app/diary/dashboard/ProfileCard.js
@@ -31,11 +31,11 @@ export default function ProfileCard() {
                         {data.username}
                     </div>
                     {/* 사용자 ID (이메일) */}
-                    <p className="text-sm text-zinc-500">
+                    <p className="text-l text-zinc-500">
                         {data.loginId}
                     </p>
                     {/* divider */}
-                    <div className="my-6 border-b-2"></div>
+                    <div className="my-3 border-b-2"></div>
                     <div className='w-full'>
                         <div className="grid grid-cols-3">
                             {/* 총 작성한 일기 수 */}

--- a/app/diary/dashboard/RecentDiaryCard.js
+++ b/app/diary/dashboard/RecentDiaryCard.js
@@ -1,10 +1,20 @@
-import userData from "../../../public/data/user.json";
+'use client';
+
 import Link from "next/link";
-// app/common/header/Profile에서 거의 다 가져왔지만 일부 수정하기 위해 component 따로 생성.
+import { useUserInfoQuery } from "../../hooks/queries/useUserInfoQuery";
+import Loading from "../list/grid/loading";
+import Error from "../list/grid/error";
+
 export default function RecentDiaryCard() {
-    const user = userData;
-    // 제일 최근 일기의 ID만 추출해서 /diary/ 뒤에 붙여줌.
-    const firstDiary = "/diary/"+user.recent_diaries[0].diary_id;
+
+    // 유저 정보 data fetching을 위한 useQuery
+    const { data, isLoading, isFetching, isFetched, isError } = useUserInfoQuery();
+
+    if( isLoading || isFetching ) return <Loading className="flex justify-center"/>
+    if ( isError ) return <Error className="flex justify-center"/>
+
+    console.log(data.recentDiaries.diaryDate)
+
     return (
         <>
             <div
@@ -32,20 +42,20 @@ export default function RecentDiaryCard() {
                     <br></br>
                     {/* 날짜 */}
                     <div className='text-xl font-extrabold text-zinc-700'>
-                        {user.recent_diaries[0].diaryDate}
+                        {data.recentDiaries.diaryDate}
                     </div>
                     {/* 썸네일 사진 */}
                     <div className="justify-center m-5 avatar">
                         <Link 
                         className="w-50 rounded-xl"
                         type="button"
-                        href={firstDiary}>
-                            <img src={user.recent_diaries[0].thumbnail}/>
+                        href={data.recentDiaries.thumbnail}>
+                            <img src={data.recentDiaries.thumbnail}/>
                         </Link>
                     </div>
                     {/* Keywords */}
                     <div className='flex flex-row justify-items-center align-middle'>
-                                        {user.recent_diaries[0].keywords.map((keyword) => (
+                                        {data.recentDiaries.keywords.map((keyword) => (
                                             <div key={keyword}
                                                  className="px-3 py-1 mb-1 mr-2 text-l align-middle font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
                                                 #{keyword}

--- a/app/diary/dashboard/RecentDiaryCard.js
+++ b/app/diary/dashboard/RecentDiaryCard.js
@@ -36,7 +36,7 @@ export default function RecentDiaryCard() {
                         </div>
                     </div>
                 </div>
-                {data.recentDiaries == null ? 
+                {data.recentDiary.diaryId == null ? 
                     <h4 className="pt-5 pl-8">
                         작성한 일기가 없습니다.
                     </h4>
@@ -45,20 +45,20 @@ export default function RecentDiaryCard() {
                     <br></br>
                     {/* 날짜 */}
                     <div className='text-xl font-extrabold text-zinc-700'>
-                        {data.recentDiaries.diaryDate}
+                        {data.recentDiary.diaryDate}
                     </div>
                     {/* 썸네일 사진 */}
                     <div className="justify-center m-5 avatar">
                         <Link 
                         className="w-50 rounded-xl"
                         type="button"
-                        href={data.recentDiaries.thumbnail}>
-                            <img src={data.recentDiaries.thumbnail}/>
+                        href={data.recentDiary.thumbnail}>
+                            <img src={data.recentDiary.thumbnail}/>
                         </Link>
                     </div>
                     {/* Keywords */}
                     <div className='flex flex-row justify-items-center align-middle'>
-                                        {data.recentDiaries.keywords.map((keyword) => (
+                                        {data.recentDiary.keywords.map((keyword) => (
                                             <div key={keyword}
                                                 className="px-3 py-1 mb-1 mr-2 text-l align-middle font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
                                                 #{keyword}

--- a/app/diary/dashboard/RecentDiaryCard.js
+++ b/app/diary/dashboard/RecentDiaryCard.js
@@ -13,8 +13,6 @@ export default function RecentDiaryCard() {
     if( isLoading || isFetching ) return <Loading className="flex justify-center"/>
     if ( isError ) return <Error className="flex justify-center"/>
 
-    console.log(data.recentDiaries.diaryDate)
-
     return (
         <>
             <div
@@ -38,7 +36,12 @@ export default function RecentDiaryCard() {
                         </div>
                     </div>
                 </div>
-                <div className='flex flex-col text-center justify-items-center'>
+                {data.recentDiaries == null ? 
+                    <h4 className="pt-5 pl-8">
+                        작성한 일기가 없습니다.
+                    </h4>
+                    :
+                    <div className='flex flex-col text-center justify-items-center'>
                     <br></br>
                     {/* 날짜 */}
                     <div className='text-xl font-extrabold text-zinc-700'>
@@ -57,7 +60,7 @@ export default function RecentDiaryCard() {
                     <div className='flex flex-row justify-items-center align-middle'>
                                         {data.recentDiaries.keywords.map((keyword) => (
                                             <div key={keyword}
-                                                 className="px-3 py-1 mb-1 mr-2 text-l align-middle font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
+                                                className="px-3 py-1 mb-1 mr-2 text-l align-middle font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
                                                 #{keyword}
                                             </div>
                                         ))}
@@ -66,7 +69,8 @@ export default function RecentDiaryCard() {
                         <div className="grid grid-cols-3">
                         </div>
                     </div>
-                </div>
+                    </div>
+                }
             </div>
         </>
         );

--- a/app/diary/dashboard/RecentDiaryCard.js
+++ b/app/diary/dashboard/RecentDiaryCard.js
@@ -17,7 +17,7 @@ export default function RecentDiaryCard() {
         <>
             <div
                 className="w-full max-w-md p-6 pt-4 mb-6 overflow-hidden text-left align-middle transition-all transform bg-zinc-100 shadow-xl lg:max-w-lg rounded-xl">
-                <div className="px-4 py-3 mb-0 border-0 rounded-t">
+                <div className="px-4 py-1 mb-0 border-0 rounded-t">
                     <div className="flex flex-wrap items-center">
                         <div className="relative flex-1 flex-grow w-full max-w-full px-4">
                         <h2 className="text-2xl font-bold text-zinc-700">
@@ -44,11 +44,11 @@ export default function RecentDiaryCard() {
                     <div className='flex flex-col text-center justify-items-center'>
                     <br></br>
                     {/* 날짜 */}
-                    <div className='text-xl font-extrabold text-zinc-700'>
+                    <div className='text-2xl font-extrabold text-zinc-700'>
                         {data.recentDiary.diaryDate}
                     </div>
                     {/* 썸네일 사진 */}
-                    <div className="justify-center m-5 avatar">
+                    <div className="justify-center m-3 avatar">
                         <Link 
                         className="w-50 rounded-xl"
                         type="button"
@@ -56,8 +56,12 @@ export default function RecentDiaryCard() {
                             <img src={data.recentDiary.thumbnail}/>
                         </Link>
                     </div>
+                    {/*감정*/}
+                    <div className='justify-items-center align-middle justify-center pb-2 text-zinc-500 text-xl'>
+                        {data.recentDiary.emotion}
+                    </div>
                     {/* Keywords */}
-                    <div className='flex flex-row justify-items-center align-middle'>
+                    <div className='flex flex-row justify-items-center align-middle justify-center flex-wrap'>
                                         {data.recentDiary.keywords.map((keyword) => (
                                             <div key={keyword}
                                                 className="px-3 py-1 mb-1 mr-2 text-l align-middle font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">

--- a/app/diary/dashboard/RecentDiaryCard.js
+++ b/app/diary/dashboard/RecentDiaryCard.js
@@ -61,7 +61,7 @@ export default function RecentDiaryCard() {
                                         {data.recentDiary.keywords.map((keyword) => (
                                             <div key={keyword}
                                                 className="px-3 py-1 mb-1 mr-2 text-l align-middle font-medium w-fit text-zinc-500 bg-zinc-200 rounded-xl dark:bg-zinc-200 dark:text-zinc-800 ">
-                                                #{keyword}
+                                                {keyword == "EXECPTION_NO_KEYWORD" ? <>#키워드 없음</> : <>#{keyword}</>}
                                             </div>
                                         ))}
                                     </div>

--- a/app/hooks/mutations/useDiaryDelete.js
+++ b/app/hooks/mutations/useDiaryDelete.js
@@ -5,20 +5,16 @@ import { deleteDiary } from "../../api/deleteDiary";
 export const useDiaryDelete = (diaryId, queryClient) =>
     useMutation(
         async () => {
-
-            let returnData = new Object();
             
             const response = await deleteDiary(diaryId)
-            .then(resp => resp.json())
+            .then(resp => resp.status != 200 ? resp.json() : resp)
             .then(respData => {
                 if(respData.errorCode) {
-                    throw respData.errorCode;
+                    throw respData;
                 }
-
-                returnData = respData;
             })
-
-            return returnData;
+            
+            return response;
         },
         {
             onSuccess: async (response) => {
@@ -27,8 +23,9 @@ export const useDiaryDelete = (diaryId, queryClient) =>
                 {
                     setCookie('todayDiaryId', "");
                 }
-                queryClient.resetQueries(["DIARY_LIST"]);
-                queryClient.resetQueries(["USER_INFO"]);
+                queryClient.invalidateQueries(["DIARY_LIST"]);
+                queryClient.invalidateQueries(["USER_INFO"]);
+                queryClient.invalidateQueries(["EMOTION_COUNT"]);
             }
         }
     );

--- a/app/hooks/mutations/useDiarySave.js
+++ b/app/hooks/mutations/useDiarySave.js
@@ -32,6 +32,7 @@ export const useDiarySave = (queryClient, saveType, diaryId) =>
                 }
                 queryClient.resetQueries(["DIARY_LIST"]);
                 queryClient.resetQueries(["USER_INFO"]);
+                queryClient.resetQueries(["EMOTION_COUNT"]);
             }
         }
     );

--- a/app/hooks/mutations/useDiarySave.js
+++ b/app/hooks/mutations/useDiarySave.js
@@ -30,9 +30,9 @@ export const useDiarySave = (queryClient, saveType, diaryId) =>
                 {
                     setCookie('todayDiaryId', data.diaryId);
                 }
-                queryClient.resetQueries(["DIARY_LIST"]);
-                queryClient.resetQueries(["USER_INFO"]);
-                queryClient.resetQueries(["EMOTION_COUNT"]);
+                queryClient.invalidateQueries(["DIARY_LIST"]);
+                queryClient.invalidateQueries(["USER_INFO"]);
+                queryClient.invalidateQueries(["EMOTION_COUNT"]);
             }
         }
     );


### PR DESCRIPTION
## 추가
1. 내 프로필의 최근 일기 데이터 패칭
2. 대시보드의 최근 일기 카드 데이터 패칭

## 수정
1. 내 프로필의 최근 일기 UI 수정
2. 대시보드의 최근 일기 카드 UI 수정
3. `ReactQueryWrapper`에 공통 에러 처리 조건 추가 (`NO_AUTHORIZATION`)
4. 일기 저장/삭제 성공 시 `EMOTION_COUNT` 쿼리 invalidate 기능 추가
5. 소셜 로그인 사용자일 경우, 프로필 이미지 및 비밀번호 변경 불가 조건 수정
6. 비밀번호 재설정 시 date-fetching해서 loginId 가져오도록 수정
7. 일기 저장 성공 시 각 쿼리 키에 대한 실행 함수 변경(`resetQueries()` -> `invalidateQueries()`)